### PR TITLE
Handle free ".js" script as CommonJS initially

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,7 +148,7 @@ Else
             Else
                 Load the file as CommonJS.
         Else we reach the file system root without finding a package.json
-            Load the file as ESM.
+            Load the file as CJS.
 ```
 
 The folder containing the located `package.json` and its subfolders are the _package scope,_ and the parent folder is on the other side of a _package boundary._ There can be multiple `package.json` files in a path, creating multiple package boundaries.


### PR DESCRIPTION
As discussed on Slack, there is an issue in Node's own scripts here where `tools/lint-js.js` is run via `node tools/lint-js.js` and that is CommonJS, yet there is no package.json present in the Node package.

Therefore this proposal is currently failing on an existing use case which seems important to maintain.

By falling back to CJS over ESM we can maintain this use case.

The suggest then was to implement a deprecation path over the next two major releases after this:
1. Initially land with no deprecation notice at all
2. In the next major release, provide a deprecation notice that `node --legacy` or similar needs to be added when running this use case of CJS at the top-level without a package.json
3. In the major release after that, throw for `node cjs.js` instead treating it as ESM by default, while still supporting `node --legacy cjs.js`.

The exact process above would still need to be fully fleshed out but that was the idea discussed to maintain this compatibility while remaining forward-looking.

Interestingly, a similar deprecation process could even work for CommonJS package.json files if we could get npm on board with injecting a legacy flag on install.